### PR TITLE
Add unfreeze_roles_from_milestone

### DIFF
--- a/osa_cli_releases/cli.py
+++ b/osa_cli_releases/cli.py
@@ -78,3 +78,15 @@ def freeze_arr():
     args = parser.parse_args()
     releasing.freeze_ansible_role_requirements_file(filename=args['file'])
 
+def unfreeze_arr():
+    """ Unfreeze all roles shas for milestone releases.
+    Also unfreezes roles from external sources.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--file",
+        help="path to ansible-role-requirements.yml file",
+        default="ansible-role-requirements.yml",
+    )
+    args = parser.parse_args()
+    releasing.unfreeze_ansible_role_requirements_file(filename=args['file'])

--- a/osa_cli_releases/click.py
+++ b/osa_cli_releases/click.py
@@ -89,3 +89,15 @@ def freeze_arr(global_ctx, **kwargs):
     releasing.freeze_ansible_role_requirements_file(filename=kwargs["file"])
 
 
+@releases.command("unfreeze_roles_from_milestone")
+@click.pass_obj
+@click.option(
+    "--file",
+    type=click.Path(file_okay=True, dir_okay=False, writable=True),
+    help="path to ansible-role-requirements.yml",
+    default="ansible-role-requirements.yml",
+)
+def unfreeze_arr(global_ctx, **kwargs):
+    """ Sets OSA roles equals to trackbranch.
+    """
+    releasing.unfreeze_ansible_role_requirements_file(filename=kwargs["file"])

--- a/osa_cli_releases/releasing.py
+++ b/osa_cli_releases/releasing.py
@@ -214,8 +214,15 @@ def freeze_ansible_role_requirements_file(filename=""):
     )
 
 
+def unfreeze_ansible_role_requirements_file(filename=""):
+    """ Freezes a-r-r for master"""
+    update_ansible_role_requirements_file(
+        filename, milestone_unfreeze=True
+    )
+
+
 def update_ansible_role_requirements_file(
-    filename="", milestone_freeze=False
+    filename="", milestone_freeze=False, milestone_unfreeze=False
 ):
     """ Updates the SHA of each of the ansible roles based on branch given in argument
     Do not do anything on master except if milestone_freeze.
@@ -252,10 +259,13 @@ def update_ansible_role_requirements_file(
                 role_repo = clone_role(
                    role["src"], trackbranch, clone_root_path, depth="1"
                 )
-                # Unfreeze on master, not bump
-                if trackbranch == "master" and not milestone_freeze:
-                    print("Unfreeze master role")
+                if milestone_unfreeze:
+                    print(f"Unfreeze {trackbranch} role")
                     role["version"] = trackbranch
+                # Do nothing when trackbranch and version are same and not freezing
+                elif trackbranch == role.get("version") and not milestone_freeze:
+                    print("Version and trackbranch equal, skipping...")
+                    pass
                 # Freeze or Bump
                 else:
                     role_head = role_repo.head()


### PR DESCRIPTION
Add option to ease process of unfreezing roles and do this
explicitly only. Assumption that if we're on master then we want to
unfreeze might lead to weird consequences.