### PR TITLE
Add support for bumping collection versions

### DIFF
--- a/osa_cli_releases/cli.py
+++ b/osa_cli_releases/cli.py
@@ -50,6 +50,19 @@ def bump_upstream_repos_shas():
     releasing.bump_upstream_repos_shas(args.path)
 
 
+def bump_acr():
+    """ Bump collection versions.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--file",
+        help="path to ansible-collection-requirements.yml file",
+        default="ansible-collection-requirements.yml",
+    )
+    args = parser.parse_args()
+    releasing.update_ansible_collection_requirements(filename=args['file'])
+
+
 def bump_arr():
     """ Bump roles SHA and copies releases notes from the openstack roles.
     Also bumps roles from external sources when the branch to bump is master.

--- a/osa_cli_releases/click.py
+++ b/osa_cli_releases/click.py
@@ -56,6 +56,22 @@ def bump_upstream_repos_shas(global_ctx, **kwargs):
     releasing.bump_upstream_repos_shas(kwargs["path"])
 
 
+@releases.command("bump_collections")
+@click.pass_obj
+@click.option(
+    "--file",
+    type=click.Path(file_okay=True, dir_okay=False, writable=True),
+    help="path to ansible-collection-requirements.yml",
+    default="ansible-collection-requirements.yml",
+)
+def bump_acr(global_ctx, **kwargs):
+    """ Bump collection versions
+    """
+    releasing.update_ansible_collection_requirements(
+        filename=kwargs["file"]
+    )
+
+
 @releases.command("bump_roles")
 @click.pass_obj
 @click.option(


### PR DESCRIPTION
At the moment all collections are being bumped manually. Instead we can
automate process easily for git-based collections at least.

This patch adds bump_collections command that riggers retrieval
and version update for a-c-r file.